### PR TITLE
feat: API 성공 및 에러 응답 템플릿 dto 구현

### DIFF
--- a/src/main/java/yun/pioneer_back/common/response/ExceptionResponseDto.java
+++ b/src/main/java/yun/pioneer_back/common/response/ExceptionResponseDto.java
@@ -1,0 +1,13 @@
+package yun.pioneer_back.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExceptionResponseDto
+{
+    private String code;
+    private String message;
+    private Object data;
+}

--- a/src/main/java/yun/pioneer_back/common/response/SuccessResponseDto.java
+++ b/src/main/java/yun/pioneer_back/common/response/SuccessResponseDto.java
@@ -1,0 +1,12 @@
+package yun.pioneer_back.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SuccessResponseDto
+{
+    private String message;
+    private Object data;
+}

--- a/src/main/java/yun/pioneer_back/domain/test/controller/TestController.java
+++ b/src/main/java/yun/pioneer_back/domain/test/controller/TestController.java
@@ -1,0 +1,37 @@
+package yun.pioneer_back.domain.test.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yun.pioneer_back.common.response.ExceptionResponseDto;
+import yun.pioneer_back.common.response.SuccessResponseDto;
+
+@RestController
+@RequestMapping("/api/test")
+public class TestController
+{
+    // API 성공 응답 테스트
+    @GetMapping("/success")
+    public ResponseEntity<SuccessResponseDto> testSuccess()
+    {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("API 성공 응답입니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // API 에러 응답 테스트
+    @GetMapping("/error")
+    public ResponseEntity<ExceptionResponseDto> testError()
+    {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ExceptionResponseDto.builder()
+                        .code("NOT_FOUND")
+                        .message("API 에러 응답입니다.")
+                        .data(null)
+                        .build());
+    }
+}


### PR DESCRIPTION
### 연관된 이슈

#2 

<br/>

### 작업 내용

API 처리에 성공했을 때와 에러가 발생했을 때 각각에 대한 응답을 처리하는 dto를 구현하였습니다.

- **`SuccessResponseDto`** : API 성공 응답 템플릿 dto
- **`ExceptionResponseDto`** : API 에러 응답 템플릿 dto

<br/>
