### PR TITLE
feat: 회원가입 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// 데이터 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	// 데이터 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// 이메일
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	// MySQL
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,28 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Spring Web
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Lombok
+	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
+
+	// Spring Data JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/yun/pioneer_back/PioneerBackApplication.java
+++ b/src/main/java/yun/pioneer_back/PioneerBackApplication.java
@@ -2,8 +2,10 @@ package yun.pioneer_back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PioneerBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/yun/pioneer_back/common/configuration/RedisConfig.java
+++ b/src/main/java/yun/pioneer_back/common/configuration/RedisConfig.java
@@ -1,0 +1,48 @@
+package yun.pioneer_back.common.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig
+{
+    private final RedisProperties redisProperties;
+
+    // host, port 연결
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // Redis 템플릿 구성
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate()
+    {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        // Redis 연결
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key-Value 형태 직렬화 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash Key-Value 형태 직렬화 설정
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 기본적으로 직렬화를 수행하도록 설정
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/entity/BaseEntity.java
+++ b/src/main/java/yun/pioneer_back/common/entity/BaseEntity.java
@@ -1,0 +1,27 @@
+package yun.pioneer_back.common.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity
+{
+    // 생성 시점
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    // 수정 시점
+    @NotNull
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/yun/pioneer_back/common/entity/User.java
+++ b/src/main/java/yun/pioneer_back/common/entity/User.java
@@ -46,7 +46,11 @@ public class User extends BaseEntity
     private UserRole role;
 
     // refresh token
-    @NotNull
     @Column(length = 255)
     private String refreshToken;
+
+    // refresh token 갱신
+    public void renewRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/yun/pioneer_back/common/entity/User.java
+++ b/src/main/java/yun/pioneer_back/common/entity/User.java
@@ -1,0 +1,52 @@
+package yun.pioneer_back.common.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import yun.pioneer_back.common.security.UserRole;
+
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"email"}),
+                @UniqueConstraint(columnNames = {"nickname"})
+        }
+)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class User extends BaseEntity
+{
+    @Id
+    @Column(nullable = false, unique = true)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 이메일
+    @NotNull
+    @Email
+    @Column(length = 255)
+    private String email;
+
+    // 비밀번호
+    @NotNull
+    @Column(length = 255)
+    private String password;
+
+    // 닉네임
+    @NotNull
+    @Column(length = 50)
+    private String nickname;
+
+    // 사용자 권한
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    // refresh token
+    @NotNull
+    @Column(length = 255)
+    private String refreshToken;
+}

--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -16,13 +16,21 @@ public enum CustomExceptionCode
     INVALID_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자 타입입니다."),
     INVALID_REQUEST_DTO(HttpStatus.BAD_REQUEST, "올바르지 않은 요청 dto입니다."),
 
-    // 이메일 및 인증번호
+    // 이메일
     SEND_EMAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 에러가 발생하였습니다."),
-    EXPIRED_VERIFICATION_CODE(HttpStatus.CONFLICT, "이미 만료된 인증번호 데이터입니다."),
-    WRONG_VERIFICATION_CODE(HttpStatus.CONFLICT, "틀린 인증번호입니다."),
 
     // Redis
     REDIS_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 작업 수행 중 에러가 발생하였습니다."),
+
+    // User 관련
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 비밀번호 형식입니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 닉네임 형식입니다."),
+    UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, "인증받지 않은 이메일입니다."),
+    CLAIMS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자 정의 클레임 값이 존재하지 않습니다."),
+    EXPIRED_VERIFICATION_CODE(HttpStatus.CONFLICT, "이미 만료된 인증번호 데이터입니다."),
+    WRONG_VERIFICATION_CODE(HttpStatus.CONFLICT, "틀린 인증번호입니다."),
+    ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    ALREADY_USED_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
     // 기타
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 예기치 못한 오류가 발생했습니다.");

--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -16,8 +16,10 @@ public enum CustomExceptionCode
     INVALID_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자 타입입니다."),
     INVALID_REQUEST_DTO(HttpStatus.BAD_REQUEST, "올바르지 않은 요청 dto입니다."),
 
-    // 이메일
+    // 이메일 및 인증번호
     SEND_EMAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 에러가 발생하였습니다."),
+    EXPIRED_VERIFICATION_CODE(HttpStatus.CONFLICT, "이미 만료된 인증번호 데이터입니다."),
+    WRONG_VERIFICATION_CODE(HttpStatus.CONFLICT, "틀린 인증번호입니다."),
 
     // Redis
     REDIS_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 작업 수행 중 에러가 발생하였습니다."),

--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -9,7 +9,18 @@ import org.springframework.http.HttpStatus;
 public enum CustomExceptionCode
 {
     // 예시
-    EXAMPLE_ERROR_CODE(HttpStatus.NOT_FOUND, "에러 코드 예시입니다.");
+    EXAMPLE_ERROR_CODE(HttpStatus.NOT_FOUND, "에러 코드 예시입니다."),
+
+    // 유효성 검사
+    INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자입니다."),
+    INVALID_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자 타입입니다."),
+    INVALID_REQUEST_DTO(HttpStatus.BAD_REQUEST, "올바르지 않은 요청 dto입니다."),
+
+    // 이메일
+    SEND_EMAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 에러가 발생하였습니다."),
+
+    // 기타
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 예기치 못한 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -19,6 +19,9 @@ public enum CustomExceptionCode
     // 이메일
     SEND_EMAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 에러가 발생하였습니다."),
 
+    // Redis
+    REDIS_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Redis 작업 수행 중 에러가 발생하였습니다."),
+
     // 기타
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 예기치 못한 오류가 발생했습니다.");
 

--- a/src/main/java/yun/pioneer_back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yun/pioneer_back/common/exception/GlobalExceptionHandler.java
@@ -3,11 +3,12 @@ package yun.pioneer_back.common.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import yun.pioneer_back.common.response.ExceptionResponseDto;
-
-import java.util.Arrays;
 
 @RestControllerAdvice
 @Slf4j
@@ -17,10 +18,7 @@ public class GlobalExceptionHandler
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ExceptionResponseDto> customExceptionHandler(CustomException e)
     {
-        log.error("[CustomException] code: {} | message: {} | data: {}",
-                e.getErrorCode().name(),
-                e.getErrorCode().getMessage(),
-                e.getData());
+        logErrorMessage(e, e.getErrorCode().name(), e.getErrorCode().getMessage(), e.getData());
 
         return ResponseEntity.status(e.getErrorCode().getHttpStatus())
                 .body(ExceptionResponseDto.builder()
@@ -30,19 +28,73 @@ public class GlobalExceptionHandler
                         .build());
     }
 
+    // 메서드 인자 유효성 검사 예외 처리 핸들러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException e)
+    {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("요청 값이 올바르지 않습니다.");
+
+        logErrorMessage(e, CustomExceptionCode.INVALID_METHOD_ARGUMENT.name(), message, null);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .code(CustomExceptionCode.INVALID_METHOD_ARGUMENT.name())
+                        .message(message)
+                        .data(null)
+                        .build());
+    }
+
+    // @PathVariable 유효성 검사 예외 처리 핸들러
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ExceptionResponseDto> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e)
+    {
+        logErrorMessage(e, CustomExceptionCode.INVALID_METHOD_ARGUMENT_TYPE.name(), e.getMessage(), null);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .code(CustomExceptionCode.INVALID_METHOD_ARGUMENT_TYPE.name())
+                        .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
+    // 요청 dto 역직렬화 예외 처리 핸들러
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponseDto> handleHttpMessageNotReadableException(HttpMessageNotReadableException e)
+    {
+        logErrorMessage(e, CustomExceptionCode.INVALID_REQUEST_DTO.name(), e.getMessage(), null);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ExceptionResponseDto.builder()
+                        .code(CustomExceptionCode.INVALID_REQUEST_DTO.name())
+                        .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
     // 그 외 모든 예외 처리 핸들러
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponseDto> globalExceptionHandler(Exception e)
     {
-        log.error("[UnhandledException] {}", e.getClass().getName(), e);
-        log.error("Message: {}", e.getMessage());
-        log.error("StackTrace: {}", Arrays.toString(e.getStackTrace()));
+        logErrorMessage(e, CustomExceptionCode.INTERNAL_SERVER_ERROR.name(), e.getMessage(), null);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ExceptionResponseDto.builder()
-                        .code("INTERNAL_SERVER_ERROR")
-                        .message("서버 내부에서 예기치 못한 오류가 발생했습니다.")
+                        .code(CustomExceptionCode.INTERNAL_SERVER_ERROR.name())
+                        .message(e.getMessage())
                         .data(null)
                         .build());
+    }
+
+    // 에러 메시지 로깅
+    private void logErrorMessage(Exception e, String code, String message, Object data)
+    {
+        log.error("[{}]", e.getClass().getName());
+        log.error("Code: {}", code);
+        log.error("Message: {}", message);
+        log.error("Data: {}", data);
     }
 }

--- a/src/main/java/yun/pioneer_back/common/repository/UserRepository.java
+++ b/src/main/java/yun/pioneer_back/common/repository/UserRepository.java
@@ -4,6 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import yun.pioneer_back.common.entity.User;
 
+import java.util.Optional;
+
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>
+{
+    // 이메일로 조회
+    Optional<User> findByEmail(String email);
+
+    // 닉네임으로 조회
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/yun/pioneer_back/common/repository/UserRepository.java
+++ b/src/main/java/yun/pioneer_back/common/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package yun.pioneer_back.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import yun.pioneer_back.common.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/yun/pioneer_back/common/security/SecurityConfig.java
+++ b/src/main/java/yun/pioneer_back/common/security/SecurityConfig.java
@@ -4,8 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @RequiredArgsConstructor
@@ -17,5 +23,20 @@ public class SecurityConfig
     @Bean
     public BCryptPasswordEncoder encoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception
+    {
+        // 기본 설정
+        httpSecurity
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .headers(c -> c.frameOptions(
+                        HeadersConfigurer.FrameOptionsConfig::disable).disable())
+                .sessionManagement(c -> c.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS));
+
+        return httpSecurity.build();
     }
 }

--- a/src/main/java/yun/pioneer_back/common/security/SecurityConfig.java
+++ b/src/main/java/yun/pioneer_back/common/security/SecurityConfig.java
@@ -1,0 +1,21 @@
+package yun.pioneer_back.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig
+{
+    // 비밀번호 인코더 설정
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/security/UserRole.java
+++ b/src/main/java/yun/pioneer_back/common/security/UserRole.java
@@ -1,0 +1,12 @@
+package yun.pioneer_back.common.security;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum UserRole
+{
+    ADMIN("관리자 권한"),
+    USER("일반 사용자 권한");
+
+    private final String description;
+}

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
@@ -1,0 +1,84 @@
+package yun.pioneer_back.common.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Service
+public class TokenService
+{
+    private final Key key;
+
+    public TokenService(@Value("${JWT_SIGNATURE_SECRET_KEY}") String secret)
+    {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 토큰 생성
+    public String createToken(TokenType tokenType)
+    {
+        Claims claims = Jwts.claims();
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime expiresAt = now.plusSeconds(tokenType.getTtl());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(expiresAt.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 생성
+    public String createToken(Long id, TokenType tokenType)
+    {
+        Claims claims = Jwts.claims();
+        claims.put("id", id);
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime expiresAt = now.plusSeconds(tokenType.getTtl());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(expiresAt.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰을 쿠키로 변환
+    public Cookie parseTokenToCookie(String token, TokenType tokenType)
+    {
+        Cookie cookie = new Cookie(tokenType.getName(), token);
+
+        cookie.setHttpOnly(tokenType.isHttpOnly());
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(tokenType.getTtl());
+        cookie.setAttribute("SameSite", "Strict");
+
+        return cookie;
+    }
+
+    // 토큰 검증
+    public boolean checkToken(String token)
+    {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
@@ -24,35 +24,35 @@ public class TokenService
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // 토큰 생성
+    // 토큰 생성 (id 제외)
     public String createToken(TokenType tokenType)
     {
         Claims claims = Jwts.claims();
 
         ZonedDateTime now = ZonedDateTime.now();
-        ZonedDateTime expiresAt = now.plusSeconds(tokenType.getTtl());
+        ZonedDateTime expiredAt = now.plusSeconds(tokenType.getTtl());
 
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(Date.from(now.toInstant()))
-                .setExpiration(Date.from(expiresAt.toInstant()))
+                .setExpiration(Date.from(expiredAt.toInstant()))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    // 토큰 생성
+    // 토큰 생성 (id 포함)
     public String createToken(Long id, TokenType tokenType)
     {
         Claims claims = Jwts.claims();
         claims.put("id", id);
 
         ZonedDateTime now = ZonedDateTime.now();
-        ZonedDateTime expiresAt = now.plusSeconds(tokenType.getTtl());
+        ZonedDateTime expiredAt = now.plusSeconds(tokenType.getTtl());
 
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(Date.from(now.toInstant()))
-                .setExpiration(Date.from(expiresAt.toInstant()))
+                .setExpiration(Date.from(expiredAt.toInstant()))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
@@ -8,6 +8,8 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import yun.pioneer_back.common.exception.CustomException;
+import yun.pioneer_back.common.exception.CustomExceptionCode;
 
 import java.security.Key;
 import java.time.ZonedDateTime;
@@ -68,6 +70,19 @@ public class TokenService
             return true;
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    // 사용자 정의 클레임 추출
+    public Object getClaims(String token, String claimsKey, Class<?> requiredType)
+    {
+        // 클레임 추출
+        Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+        if(claims.containsKey(claimsKey)) {
+            return claims.get(claimsKey, requiredType);
+        } else {
+            throw new CustomException(CustomExceptionCode.CLAIMS_NOT_FOUND, claimsKey);
         }
     }
 }

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.security.Key;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.Map;
 
 @Service
 public class TokenService
@@ -24,27 +25,15 @@ public class TokenService
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    // 토큰 생성 (id 제외)
-    public String createToken(TokenType tokenType)
+    // 토큰 생성
+    public String createToken(TokenType tokenType, Map<String, Object> claimsMap)
     {
         Claims claims = Jwts.claims();
 
-        ZonedDateTime now = ZonedDateTime.now();
-        ZonedDateTime expiredAt = now.plusSeconds(tokenType.getTtl());
-
-        return Jwts.builder()
-                .setClaims(claims)
-                .setIssuedAt(Date.from(now.toInstant()))
-                .setExpiration(Date.from(expiredAt.toInstant()))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
-    }
-
-    // 토큰 생성 (id 포함)
-    public String createToken(Long id, TokenType tokenType)
-    {
-        Claims claims = Jwts.claims();
-        claims.put("id", id);
+        // 사용자 정의 클레임 추가
+        if (claimsMap != null) {
+            claims.putAll(claimsMap);
+        }
 
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime expiredAt = now.plusSeconds(tokenType.getTtl());

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenService.java
@@ -74,7 +74,7 @@ public class TokenService
     }
 
     // 사용자 정의 클레임 추출
-    public Object getClaims(String token, String claimsKey, Class<?> requiredType)
+    public <T> T getClaims(String token, String claimsKey, Class<T> requiredType)
     {
         // 클레임 추출
         Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenType.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenType.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public enum TokenType
 {
-    EMAIL_VERIFICATION_TOKEN("email-verification-token", 60 * 60, false),
+    EMAIL_VERIFICATION_TOKEN("email-verification-token", 60 * 60, true),
     ACCESS_TOKEN("access-token", 60 * 60, false),
     REFRESH_TOKEN("refresh-token", 60 * 60 * 24 * 30, true);
 

--- a/src/main/java/yun/pioneer_back/common/security/jwt/TokenType.java
+++ b/src/main/java/yun/pioneer_back/common/security/jwt/TokenType.java
@@ -1,0 +1,17 @@
+package yun.pioneer_back.common.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum TokenType
+{
+    EMAIL_VERIFICATION_TOKEN("email-verification-token", 60 * 60, false),
+    ACCESS_TOKEN("access-token", 60 * 60, false),
+    REFRESH_TOKEN("refresh-token", 60 * 60 * 24 * 30, true);
+
+    private final String name;
+    private final int ttl;
+    private final boolean isHttpOnly;
+}

--- a/src/main/java/yun/pioneer_back/common/util/EmailUtil.java
+++ b/src/main/java/yun/pioneer_back/common/util/EmailUtil.java
@@ -1,0 +1,36 @@
+package yun.pioneer_back.common.util;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import yun.pioneer_back.common.exception.CustomException;
+import yun.pioneer_back.common.exception.CustomExceptionCode;
+
+@Service
+@RequiredArgsConstructor
+public class EmailUtil
+{
+    private final JavaMailSender mailSender;
+
+    // 이메일 전송
+    public void sendEmail(String to, String subject, String content)
+    {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+
+            // 수신 이메일, 제목, 내용 설정
+            mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(content, true);
+
+            // 이메일 전송
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new CustomException(CustomExceptionCode.SEND_EMAIL_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/util/RedisUtil.java
+++ b/src/main/java/yun/pioneer_back/common/util/RedisUtil.java
@@ -1,0 +1,50 @@
+package yun.pioneer_back.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil
+{
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 데이터 저장 (유효기간 x)
+    @Transactional
+    public void set(String key, Object value)
+    {
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ops.set(key, value);
+    }
+
+    // 데이터 저장 (유효기간 o)
+    @Transactional
+    public void set(String key, Object value, Duration duration)
+    {
+        ValueOperations<String, Object> ops = redisTemplate.opsForValue();
+        ops.set(key, value, duration);
+    }
+
+    // 데이터 조회
+    @Transactional(readOnly = true)
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    // 데이터 삭제
+    @Transactional
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    // 데이터 존재 여부 확인
+    @Transactional(readOnly = true)
+    public boolean isPresent(String key) {
+        return redisTemplate.opsForValue().get(key) != null;
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/util/RedisUtil.java
+++ b/src/main/java/yun/pioneer_back/common/util/RedisUtil.java
@@ -41,10 +41,4 @@ public class RedisUtil
     public void delete(String key) {
         redisTemplate.delete(key);
     }
-
-    // 데이터 존재 여부 확인
-    @Transactional(readOnly = true)
-    public boolean isPresent(String key) {
-        return redisTemplate.opsForValue().get(key) != null;
-    }
 }

--- a/src/main/java/yun/pioneer_back/domain/test/TestController.java
+++ b/src/main/java/yun/pioneer_back/domain/test/TestController.java
@@ -2,6 +2,7 @@ package yun.pioneer_back.domain.test;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,6 +17,7 @@ public class TestController
 {
     // API 성공 응답 테스트
     @GetMapping("/success")
+    @PreAuthorize("permitAll()")
     public ResponseEntity<SuccessResponseDto> testSuccess()
     {
         return ResponseEntity.status(HttpStatus.OK)
@@ -27,6 +29,7 @@ public class TestController
 
     // API 에러 응답 테스트
     @GetMapping("/error")
+    @PreAuthorize("permitAll()")
     public ResponseEntity<ExceptionResponseDto> testError()
     {
         throw new CustomException(CustomExceptionCode.EXAMPLE_ERROR_CODE, null);

--- a/src/main/java/yun/pioneer_back/domain/test/TestController.java
+++ b/src/main/java/yun/pioneer_back/domain/test/TestController.java
@@ -1,4 +1,4 @@
-package yun.pioneer_back.domain.test.controller;
+package yun.pioneer_back.domain.test;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
+++ b/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
@@ -6,12 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import yun.pioneer_back.common.response.SuccessResponseDto;
 import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
+import yun.pioneer_back.domain.user.dto.JoinReqDto;
 import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
 import yun.pioneer_back.domain.user.service.UserService;
 
@@ -47,6 +45,22 @@ public class UserController
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
                         .message("이메일 인증번호를 성공적으로 확인하였습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 회원가입
+    @PostMapping("/join")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> join(@Valid @RequestBody JoinReqDto reqDto,
+                                                   @CookieValue(name = "email-verification-token") String verificationToken,
+                                                   HttpServletResponse response)
+    {
+        userService.join(reqDto, verificationToken, response);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("성공적으로 회원가입 되었습니다.")
                         .data(null)
                         .build());
     }

--- a/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
+++ b/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package yun.pioneer_back.domain.user.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yun.pioneer_back.common.response.SuccessResponseDto;
+import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
 import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
 import yun.pioneer_back.domain.user.service.UserService;
 
@@ -30,6 +32,21 @@ public class UserController
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponseDto.builder()
                         .message("이메일 인증번호를 성공적으로 전송하였습니다.")
+                        .data(null)
+                        .build());
+    }
+
+    // 이메일 인증번호 확인
+    @PostMapping("/check-verification-code")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> checkVerificationCode(@Valid @RequestBody CheckVerificationCodeReqDto reqDto,
+                                                                    HttpServletResponse response)
+    {
+        userService.checkVerificationCode(reqDto, response);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("이메일 인증번호를 성공적으로 확인하였습니다.")
                         .data(null)
                         .build());
     }

--- a/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
+++ b/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package yun.pioneer_back.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yun.pioneer_back.common.response.SuccessResponseDto;
+import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
+import yun.pioneer_back.domain.user.service.UserService;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController
+{
+    private final UserService userService;
+
+    // 이메일 인증번호 전송
+    @PostMapping("/send-verification-code")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> sendVerificationCode(@Valid @RequestBody SendVerificationCodeReqDto reqDto)
+    {
+        userService.sendVerificationCode(reqDto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("이메일 인증번호를 성공적으로 전송하였습니다.")
+                        .data(null)
+                        .build());
+    }
+}

--- a/src/main/java/yun/pioneer_back/domain/user/dto/CheckVerificationCodeReqDto.java
+++ b/src/main/java/yun/pioneer_back/domain/user/dto/CheckVerificationCodeReqDto.java
@@ -1,0 +1,16 @@
+package yun.pioneer_back.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class CheckVerificationCodeReqDto
+{
+    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "인증번호를 입력해주세요.")
+    private String verificationCode;
+}

--- a/src/main/java/yun/pioneer_back/domain/user/dto/JoinReqDto.java
+++ b/src/main/java/yun/pioneer_back/domain/user/dto/JoinReqDto.java
@@ -1,0 +1,20 @@
+package yun.pioneer_back.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class JoinReqDto
+{
+    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @Size(min = 8, max = 20, message = "비밀번호는 8글자 이상, 20글자 이하입니다.")
+    private String password;
+
+    @Size(min = 2, max = 12, message = "닉네임은 2글자 이상, 12글자 이하입니다.")
+    private String nickname;
+}

--- a/src/main/java/yun/pioneer_back/domain/user/dto/SendVerificationCodeReqDto.java
+++ b/src/main/java/yun/pioneer_back/domain/user/dto/SendVerificationCodeReqDto.java
@@ -1,0 +1,13 @@
+package yun.pioneer_back.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SendVerificationCodeReqDto
+{
+    @Email
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+}

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -1,0 +1,49 @@
+package yun.pioneer_back.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yun.pioneer_back.common.util.EmailUtil;
+import yun.pioneer_back.common.util.RedisUtil;
+import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class UserService
+{
+    private final EmailUtil emailUtil;
+    private final RedisUtil redisUtil;
+
+    // 이메일 인증번호 전송
+    @Transactional
+    public void sendVerificationCode(SendVerificationCodeReqDto reqDto)
+    {
+        // 무작위 인증번호 생성
+        SecureRandom random = new SecureRandom();
+        int number = random.nextInt(1_0000_0000);
+        String verificationCode = String.format("%08d", number);
+
+        // Redis에 저장
+        redisUtil.set("email:verification_code:" + reqDto.getEmail(), verificationCode, Duration.ofMinutes(10));
+
+        // 이메일 전송
+        emailUtil.sendEmail(
+                reqDto.getEmail(),
+                "[서부의 바람은, 손끝으로 분다] 이메일 인증번호",
+                String.format(
+                        """
+                            <div style="display: flex; flex-direction: column; align-items: center; margin: 20px;">
+                                <div style="width: 100%%; font-size: 1.125rem; font-weight: 400; color: #373737; margin-top: 50px;">
+                                    다음 인증번호를 <b>인증번호 확인란</b>에 입력하시게. <br />
+                                    인증번호가 틀리면 다시 인증번호가 전송되니 주의하도록!
+                                </div>
+                                <div style="font-size: 2.5rem; font-weight: 600; color: #373737; margin-top: 100px; margin-bottom: 100px;">%s</div>
+                            </div>
+                        """,
+                        verificationCode
+                ));
+    }
+}

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -1,14 +1,22 @@
 package yun.pioneer_back.domain.user.service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yun.pioneer_back.common.exception.CustomException;
+import yun.pioneer_back.common.exception.CustomExceptionCode;
+import yun.pioneer_back.common.security.jwt.TokenService;
+import yun.pioneer_back.common.security.jwt.TokenType;
 import yun.pioneer_back.common.util.EmailUtil;
 import yun.pioneer_back.common.util.RedisUtil;
+import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
 import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
 
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +24,8 @@ public class UserService
 {
     private final EmailUtil emailUtil;
     private final RedisUtil redisUtil;
+
+    private final TokenService tokenService;
 
     // 이메일 인증번호 전송
     @Transactional
@@ -26,7 +36,7 @@ public class UserService
         int number = random.nextInt(1_0000_0000);
         String verificationCode = String.format("%08d", number);
 
-        // Redis에 저장
+        // Redis에 <이메일, 인증번호> 데이터 저장
         redisUtil.set("email:verification_code:" + reqDto.getEmail(), verificationCode, Duration.ofMinutes(10));
 
         // 이메일 전송
@@ -38,12 +48,50 @@ public class UserService
                             <div style="display: flex; flex-direction: column; align-items: center; margin: 20px;">
                                 <div style="width: 100%%; font-size: 1.125rem; font-weight: 400; color: #373737; margin-top: 50px;">
                                     다음 인증번호를 <b>인증번호 확인란</b>에 입력하시게. <br />
-                                    인증번호가 틀리면 다시 인증번호가 전송되니 주의하도록!
+                                    인증번호가 틀리면 인증번호를 다시 전송해야 하니 주의하도록!
                                 </div>
                                 <div style="font-size: 2.5rem; font-weight: 600; color: #373737; margin-top: 100px; margin-bottom: 100px;">%s</div>
                             </div>
                         """,
                         verificationCode
                 ));
+    }
+
+    // 이메일 인증번호 확인
+    @Transactional
+    public void checkVerificationCode(CheckVerificationCodeReqDto reqDto, HttpServletResponse response)
+    {
+        // Redis에서 인증번호 조회
+        Object verificationCodeValue = redisUtil.get("email:verification_code:" + reqDto.getEmail());
+
+        // 인증번호 데이터가 존재하지 않는다면, 인증번호 만료 예외 처리
+        if(verificationCodeValue == null) {
+            throw new CustomException(CustomExceptionCode.EXPIRED_VERIFICATION_CODE, null);
+        }
+
+        // 올바른 인증번호
+        String verificationCode = (String) verificationCodeValue;
+
+        // 인증번호가 틀린 경우
+        if(!verificationCode.equals(reqDto.getVerificationCode()))
+        {
+            // 인증번호 데이터 삭제
+            redisUtil.delete("email:verification_code:" + reqDto.getEmail());
+
+            // 예외 처리
+            throw new CustomException(CustomExceptionCode.WRONG_VERIFICATION_CODE, null);
+        }
+
+        // 이메일 인증 토큰 발급
+        String verificationToken = tokenService.createToken(
+                TokenType.EMAIL_VERIFICATION_TOKEN,
+                Map.of("email", reqDto.getEmail())
+        );
+
+        // 토큰을 쿠키로 변환
+        Cookie verificationCookie = tokenService.parseTokenToCookie(verificationToken, TokenType.EMAIL_VERIFICATION_TOKEN);
+
+        // 쿠키를 응답에 포함
+        response.addCookie(verificationCookie);
     }
 }

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -3,29 +3,45 @@ package yun.pioneer_back.domain.user.service;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yun.pioneer_back.common.entity.User;
 import yun.pioneer_back.common.exception.CustomException;
 import yun.pioneer_back.common.exception.CustomExceptionCode;
+import yun.pioneer_back.common.repository.UserRepository;
+import yun.pioneer_back.common.security.UserRole;
 import yun.pioneer_back.common.security.jwt.TokenService;
 import yun.pioneer_back.common.security.jwt.TokenType;
 import yun.pioneer_back.common.util.EmailUtil;
 import yun.pioneer_back.common.util.RedisUtil;
 import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
+import yun.pioneer_back.domain.user.dto.JoinReqDto;
 import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
 
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class UserService
 {
+    private final UserRepository userRepository;
+
     private final EmailUtil emailUtil;
     private final RedisUtil redisUtil;
 
     private final TokenService tokenService;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    // 8~20 글자, (영문, 숫자, 특수문자)를 모두 포함
+    private final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?])[A-Za-z\\d!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]{8,20}$";
+
+    // 2~12 글자, (영문, 한글, 숫자)만 허용
+    private final String NICKNAME_REGEX = "^[A-Za-z0-9가-힣]{2,12}$";
 
     // 이메일 인증번호 전송
     @Transactional
@@ -93,5 +109,67 @@ public class UserService
 
         // 쿠키를 응답에 포함
         response.addCookie(verificationCookie);
+    }
+
+    // 회원가입
+    @Transactional
+    public void join(JoinReqDto reqDto, String verificationToken, HttpServletResponse response)
+    {
+        // 이메일 인증 토큰 검증
+        tokenService.checkToken(verificationToken);
+
+        // 이메일 인증 토큰 내의 이메일 정보 추출
+        String verifiedEmail = tokenService.getClaims(verificationToken, "email", String.class);
+
+        // 이메일 인증 여부 확인
+        if(!verifiedEmail.equals(reqDto.getEmail())) {
+            throw new CustomException(CustomExceptionCode.UNAUTHORIZED_EMAIL, reqDto.getEmail());
+        }
+
+        // 비밀번호 형식 체크
+        if(!Pattern.matches(PASSWORD_REGEX, reqDto.getPassword())) {
+            throw new CustomException(CustomExceptionCode.INVALID_PASSWORD_FORMAT, reqDto.getPassword());
+        }
+
+        // 닉네임 형식 체크
+        if(!Pattern.matches(NICKNAME_REGEX, reqDto.getNickname())) {
+            throw new CustomException(CustomExceptionCode.INVALID_NICKNAME_FORMAT, reqDto.getNickname());
+        }
+
+        // 이메일 중복 확인
+        if(userRepository.findByEmail(reqDto.getEmail()).isPresent()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_USED_EMAIL, reqDto.getEmail());
+        }
+
+        // 닉네임 중복 확인
+        if(userRepository.findByNickname(reqDto.getNickname()).isPresent()) {
+            throw new CustomException(CustomExceptionCode.ALREADY_USED_NICKNAME, reqDto.getNickname());
+        }
+
+        // 사용자 정보 생성
+        User user = User.builder()
+                .email(reqDto.getEmail())
+                .password(bCryptPasswordEncoder.encode(reqDto.getPassword()))
+                .nickname(reqDto.getNickname())
+                .role(UserRole.USER)
+                .build();
+
+        // 사용자 정보 저장
+        userRepository.save(user);
+
+        // access token 및 refresh token 발급
+        String accessToken = tokenService.createToken(TokenType.ACCESS_TOKEN, Map.of("userId", user.getId()));
+        String refreshToken = tokenService.createToken(TokenType.REFRESH_TOKEN, Map.of("userId", user.getId()));
+
+        // 사용자 refresh tooken 정보 입력
+        user.renewRefreshToken(refreshToken);
+
+        // 토큰을 쿠키로 변환
+        Cookie accessTokenCookie = tokenService.parseTokenToCookie(accessToken, TokenType.ACCESS_TOKEN);
+        Cookie refreshTokenCookie = tokenService.parseTokenToCookie(refreshToken, TokenType.REFRESH_TOKEN);
+
+        // 쿠키를 응답에 포함
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,12 @@ spring:
     hibernate:
       ddl-auto: update
 
+  ## Redis
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   ## 이메일
   mail:
     host: smtp.gmail.com

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,17 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+  ## 이메일
+  mail:
+    host: smtp.gmail.com
+    port: ${EMAIL_PORT}
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true


### PR DESCRIPTION
### 연관된 이슈

#3 

<br/>

### 작업 내용

다음 3개의 API를 구현하였습니다.
- 이메일 인증번호 전송
- 이메일 인증번호 확인
- 회원가입

<br/>

이메일 인증번호를 전송하면, **redis**에 (이메일, 인증번호) 데이터가 저장됩니다.
이메일 인증번호 확인은 해당 데이터를 기반으로 수행되며, 성공하면 **이메일 인증 토큰**을 쿠키로 응답합니다.
해당 쿠키는 회원가입 시에 이메일 인증 여부를 확인하기 위해 사용합니다.
회원가입에 성공하면, **access token** 및 **refresh token**을 발급하여 쿠키로 응답합니다.

<br/>
