### PR TITLE
feat: access token 재발급 API 구현

### DIFF
--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -15,6 +15,7 @@ public enum CustomExceptionCode
     INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자입니다."),
     INVALID_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 메서드 인자 타입입니다."),
     INVALID_REQUEST_DTO(HttpStatus.BAD_REQUEST, "올바르지 않은 요청 dto입니다."),
+    COOKIE_NOT_FOUND(HttpStatus.BAD_REQUEST, "쿠키가 존재하지 않습니다."),
 
     // 이메일
     SEND_EMAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송 중 에러가 발생하였습니다."),

--- a/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
+++ b/src/main/java/yun/pioneer_back/common/exception/CustomExceptionCode.java
@@ -26,6 +26,8 @@ public enum CustomExceptionCode
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "로그인에 실패하였습니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 비밀번호 형식입니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 닉네임 형식입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 refresh token 입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 refresh token 입니다."),
     UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, "인증받지 않은 이메일입니다."),
     NOT_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다"),
     LOW_AUTHORITY(HttpStatus.FORBIDDEN, "권한이 부족합니다."),

--- a/src/main/java/yun/pioneer_back/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yun/pioneer_back/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package yun.pioneer_back.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler
 
         logErrorMessage(e, CustomExceptionCode.INVALID_METHOD_ARGUMENT.name(), message, null);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(CustomExceptionCode.INVALID_METHOD_ARGUMENT.getHttpStatus())
                 .body(ExceptionResponseDto.builder()
                         .code(CustomExceptionCode.INVALID_METHOD_ARGUMENT.name())
                         .message(message)
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler
     {
         logErrorMessage(e, CustomExceptionCode.INVALID_METHOD_ARGUMENT_TYPE.name(), e.getMessage(), null);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(CustomExceptionCode.INVALID_METHOD_ARGUMENT_TYPE.getHttpStatus())
                 .body(ExceptionResponseDto.builder()
                         .code(CustomExceptionCode.INVALID_METHOD_ARGUMENT_TYPE.name())
                         .message(e.getMessage())
@@ -67,9 +67,23 @@ public class GlobalExceptionHandler
     {
         logErrorMessage(e, CustomExceptionCode.INVALID_REQUEST_DTO.name(), e.getMessage(), null);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(CustomExceptionCode.INVALID_REQUEST_DTO.getHttpStatus())
                 .body(ExceptionResponseDto.builder()
                         .code(CustomExceptionCode.INVALID_REQUEST_DTO.name())
+                        .message(e.getMessage())
+                        .data(null)
+                        .build());
+    }
+
+    // 쿠키 존재 여부 예외 처리 핸들러
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ExceptionResponseDto> handleMissingRequestCookieException(MissingRequestCookieException e)
+    {
+        logErrorMessage(e, CustomExceptionCode.COOKIE_NOT_FOUND.name(), e.getMessage(), null);
+
+        return ResponseEntity.status(CustomExceptionCode.COOKIE_NOT_FOUND.getHttpStatus())
+                .body(ExceptionResponseDto.builder()
+                        .code(CustomExceptionCode.COOKIE_NOT_FOUND.name())
                         .message(e.getMessage())
                         .data(null)
                         .build());

--- a/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
+++ b/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
@@ -92,4 +92,19 @@ public class UserController
                         .data(null)
                         .build());
     }
+
+    // access token 재발급
+    @PostMapping("/refresh-access-token")
+    @PreAuthorize("permitAll()")
+    public ResponseEntity<SuccessResponseDto> refreshAccessToken(@CookieValue(name = "refresh-token") String refreshToken,
+                                                                 HttpServletResponse response)
+    {
+        userService.refreshAccessToken(refreshToken, response);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("access token 재발급에 성공하였습니다.")
+                        .data(null)
+                        .build());
+    }
 }

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import yun.pioneer_back.common.exception.CustomException;
 import yun.pioneer_back.common.exception.CustomExceptionCode;
 import yun.pioneer_back.common.repository.UserRepository;
 import yun.pioneer_back.common.entity.UserRole;
+import yun.pioneer_back.common.response.SuccessResponseDto;
 import yun.pioneer_back.common.security.jwt.TokenService;
 import yun.pioneer_back.common.security.jwt.TokenType;
 import yun.pioneer_back.common.util.EmailUtil;
@@ -263,5 +264,34 @@ public class UserService
                                 </div>
                             """);
         }
+    }
+
+    // access token 재발급
+    @Transactional
+    public void refreshAccessToken(String refreshToken, HttpServletResponse response)
+    {
+        // refresh token 유효성 체크
+        if(!tokenService.checkToken(refreshToken)) {
+            throw new CustomException(CustomExceptionCode.INVALID_REFRESH_TOKEN, null);
+        }
+
+        // refresh token에서 사용자 정보 추출
+        Long userId = tokenService.getClaims(refreshToken, "userId", Long.class);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(CustomExceptionCode.USER_NOT_FOUND, null));
+
+        // refresh token 만료 여부 체크
+        if(!user.getRefreshToken().equals(refreshToken)) {
+            throw new CustomException(CustomExceptionCode.EXPIRED_REFRESH_TOKEN, null);
+        }
+
+        // access token 발급
+        String accessToken = tokenService.createToken(TokenType.ACCESS_TOKEN, Map.of("userId", user.getId()));
+
+        // 토큰을 쿠키로 변환
+        Cookie accessTokenCookie = tokenService.parseTokenToCookie(accessToken, TokenType.ACCESS_TOKEN);
+
+        // 쿠키를 응답에 포함
+        response.addCookie(accessTokenCookie);
     }
 }


### PR DESCRIPTION
### 연관된 이슈

#20 

<br/>

### 작업 내용

refresh token을 통해 access token을 재발급하는 API를 구현하였습니다.
동작 과정은 다음과 같습니다.
1. refresh token 유효성 검사
2. refresh token으로 부터 사용자 ID를 추출하여 사용자 정보 불러오기
3. 사용자 정보 내의 refresh token이 요청으로 보낸 토큰과 동일한지 확인함으로써 만료 여부 검사
4. access token 재발급 (쿠키)

<br/>
