### PR TITLE
feat: 레벨업에 필요한 총 경험치 계산 로직 구현 및 기본 프로필 정보 조회 API 구현

### DIFF
--- a/src/main/java/yun/pioneer_back/PioneerBackApplication.java
+++ b/src/main/java/yun/pioneer_back/PioneerBackApplication.java
@@ -2,10 +2,12 @@ package yun.pioneer_back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@ConfigurationPropertiesScan
 public class PioneerBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/yun/pioneer_back/common/configuration/LevelConfig.java
+++ b/src/main/java/yun/pioneer_back/common/configuration/LevelConfig.java
@@ -1,0 +1,24 @@
+package yun.pioneer_back.common.configuration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "level")
+@Getter
+public class LevelConfig
+{
+    private final List<LevelRule> rules;
+
+    @RequiredArgsConstructor
+    @Getter
+    public static class LevelRule
+    {
+        private final int min;
+        private final int max;
+        private final int requiredExp;
+    }
+}

--- a/src/main/java/yun/pioneer_back/common/util/LevelUtil.java
+++ b/src/main/java/yun/pioneer_back/common/util/LevelUtil.java
@@ -1,0 +1,22 @@
+package yun.pioneer_back.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yun.pioneer_back.common.configuration.LevelConfig;
+
+@Service
+@RequiredArgsConstructor
+public class LevelUtil
+{
+    private final LevelConfig levelConfig;
+
+    // 다음 레벨로 가기 위한 경험치 계산
+    public int getRequiredExp(int level)
+    {
+        return levelConfig.getRules().stream()
+                .filter(rule -> rule.getMin() <= level && level <= rule.getMax())
+                .findFirst()
+                .orElseThrow()
+                .getRequiredExp();
+    }
+}

--- a/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
+++ b/src/main/java/yun/pioneer_back/domain/user/controller/UserController.java
@@ -6,12 +6,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import yun.pioneer_back.common.entity.User;
 import yun.pioneer_back.common.response.SuccessResponseDto;
-import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
-import yun.pioneer_back.domain.user.dto.JoinReqDto;
-import yun.pioneer_back.domain.user.dto.ResetPasswordReqDto;
-import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
+import yun.pioneer_back.common.security.CustomUserDetails;
+import yun.pioneer_back.domain.user.dto.*;
 import yun.pioneer_back.domain.user.service.UserService;
 
 @RestController
@@ -105,6 +105,21 @@ public class UserController
                 .body(SuccessResponseDto.builder()
                         .message("access token 재발급에 성공하였습니다.")
                         .data(null)
+                        .build());
+    }
+
+    // 기본 프로필 정보 조회
+    @GetMapping("/basic-info")
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
+    public ResponseEntity<SuccessResponseDto> getBasicUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails)
+    {
+        User user = userDetails.getUser();
+        GetBasicUserInfoResDto data = userService.getBasicUserInfo(user);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponseDto.builder()
+                        .message("기본 프로필 정보를 성공적으로 조회하였습니다.")
+                        .data(data)
                         .build());
     }
 }

--- a/src/main/java/yun/pioneer_back/domain/user/dto/GetBasicUserInfoResDto.java
+++ b/src/main/java/yun/pioneer_back/domain/user/dto/GetBasicUserInfoResDto.java
@@ -1,0 +1,14 @@
+package yun.pioneer_back.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetBasicUserInfoResDto
+{
+    private String nickname;    // 닉네임
+    private int level;          // 레벨
+    private int exp;            // 현재 경험치
+    private int requiredExp;    // 레벨업에 필요한 총 경험치
+}

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package yun.pioneer_back.domain.user.service;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,21 +12,19 @@ import yun.pioneer_back.common.exception.CustomException;
 import yun.pioneer_back.common.exception.CustomExceptionCode;
 import yun.pioneer_back.common.repository.UserRepository;
 import yun.pioneer_back.common.entity.UserRole;
-import yun.pioneer_back.common.response.SuccessResponseDto;
 import yun.pioneer_back.common.security.jwt.TokenService;
 import yun.pioneer_back.common.security.jwt.TokenType;
 import yun.pioneer_back.common.util.EmailUtil;
+import yun.pioneer_back.common.util.LevelUtil;
 import yun.pioneer_back.common.util.RedisUtil;
-import yun.pioneer_back.domain.user.dto.CheckVerificationCodeReqDto;
-import yun.pioneer_back.domain.user.dto.JoinReqDto;
-import yun.pioneer_back.domain.user.dto.ResetPasswordReqDto;
-import yun.pioneer_back.domain.user.dto.SendVerificationCodeReqDto;
+import yun.pioneer_back.domain.user.dto.*;
 
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.*;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService
@@ -34,6 +33,7 @@ public class UserService
 
     private final EmailUtil emailUtil;
     private final RedisUtil redisUtil;
+    private final LevelUtil levelUtil;
 
     private final TokenService tokenService;
 
@@ -293,5 +293,17 @@ public class UserService
 
         // 쿠키를 응답에 포함
         response.addCookie(accessTokenCookie);
+    }
+
+    // 기본 프로필 정보 조회
+    @Transactional(readOnly = true)
+    public GetBasicUserInfoResDto getBasicUserInfo(User user)
+    {
+        return GetBasicUserInfoResDto.builder()
+                .nickname(user.getNickname())
+                .level(user.getLevel())
+                .exp(user.getExp())
+                .requiredExp(levelUtil.getRequiredExp(user.getLevel()))
+                .build();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,10 @@ spring:
   application:
     name: pioneer-back
 
+  ## 외부 yml 파일 추가
+  config:
+    import: classpath:level-system.yml
+
   ## MySQL
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/level-system.yml
+++ b/src/main/resources/level-system.yml
@@ -1,0 +1,30 @@
+level:
+  rules:
+
+    - min: 0
+      max: 0
+      requiredExp: 1
+
+    - min: 1
+      max: 9
+      requiredExp: 3
+
+    - min: 10
+      max: 49
+      requiredExp: 5
+
+    - min: 50
+      max: 99
+      requiredExp: 8
+
+    - min: 100
+      max: 199
+      requiredExp: 10
+
+    - min: 200
+      max: 499
+      requiredExp: 15
+
+    - min: 500
+      max: 999
+      requiredExp: 20


### PR DESCRIPTION
### 연관된 이슈

#22 

<br/>

### 작업 내용

기본 프로필 정보 조회 API를 구현하였습니다.
이때, 해당 정보에는 레벨업을 위해 필요한 총 경험치도 포함됩니다.

각각의 레벨에서 레벨업을 위해 필요한 총 경험치 정보를 다음과 같이 관리합니다.

- **level-system.yml** : 각각의 레벨에서 레벨업에 필요한 총 경험치에 대한 정보가 입력된 설정 파일
- **LevelConfig** : level-system.yml 파일의 정보를 리스트로 관리하는 클래스
- **LevelUtil** : 레벨과 관련된 유틸 메서드를 가지고 있는 클래스

<br/>

😉 **LevelUtil** 클래스의 **getRequiredExp** 메서드를 통해, 특정 레벨에서 레벨업을 위해 필요한 총 경험치를 얻을 수 있습니다.

<br/>
