### PR TITLE
feat: 무기 소유 엔티티 구현 및 회원가입 로직 수정

### DIFF
--- a/src/main/java/yun/pioneer_back/common/entity/OwnWeapon.java
+++ b/src/main/java/yun/pioneer_back/common/entity/OwnWeapon.java
@@ -1,0 +1,35 @@
+package yun.pioneer_back.common.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"owner", "weapon"})
+        }
+)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class OwnWeapon extends BaseEntity
+{
+    @Id
+    @Column(nullable = false, unique = true)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 소유자
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner")
+    private User owner;
+
+    // 무기
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "weapon")
+    private Weapon weapon;
+}

--- a/src/main/java/yun/pioneer_back/common/entity/User.java
+++ b/src/main/java/yun/pioneer_back/common/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_weapon")
-    private Weapon mainWeapon;
+    private OwnWeapon mainWeapon;
 
     // 이메일
     @NotNull

--- a/src/main/java/yun/pioneer_back/common/entity/User.java
+++ b/src/main/java/yun/pioneer_back/common/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_weapon")
-    private OwnWeapon mainWeapon;
+    private Weapon mainWeapon;
 
     // 이메일
     @NotNull
@@ -88,5 +88,10 @@ public class User extends BaseEntity
     // 프로필 이미지 변경
     public void updateProfileImage(UserProfileImage profileImage) {
         this.profileImage = profileImage;
+    }
+
+    // 주 무기 변경
+    public void updateMainWeapon(Weapon weapon) {
+        this.mainWeapon = weapon;
     }
 }

--- a/src/main/java/yun/pioneer_back/common/repository/OwnWeaponRepository.java
+++ b/src/main/java/yun/pioneer_back/common/repository/OwnWeaponRepository.java
@@ -1,0 +1,10 @@
+package yun.pioneer_back.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import yun.pioneer_back.common.entity.OwnWeapon;
+
+@Repository
+public interface OwnWeaponRepository extends JpaRepository<OwnWeapon, Long>
+{
+}

--- a/src/main/java/yun/pioneer_back/common/repository/WeaponRepository.java
+++ b/src/main/java/yun/pioneer_back/common/repository/WeaponRepository.java
@@ -1,10 +1,13 @@
 package yun.pioneer_back.common.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import yun.pioneer_back.common.entity.Weapon;
 
 @Repository
 public interface WeaponRepository extends JpaRepository<Weapon, Long>
 {
+    @Query("select w from Weapon w where w.name = '리볼버'")
+    Weapon findBasicWeapon();
 }

--- a/src/main/java/yun/pioneer_back/common/repository/WeaponRepository.java
+++ b/src/main/java/yun/pioneer_back/common/repository/WeaponRepository.java
@@ -1,0 +1,10 @@
+package yun.pioneer_back.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import yun.pioneer_back.common.entity.Weapon;
+
+@Repository
+public interface WeaponRepository extends JpaRepository<Weapon, Long>
+{
+}

--- a/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
+++ b/src/main/java/yun/pioneer_back/domain/user/service/UserService.java
@@ -7,12 +7,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import yun.pioneer_back.common.entity.User;
-import yun.pioneer_back.common.entity.UserProfileImage;
+import yun.pioneer_back.common.entity.*;
 import yun.pioneer_back.common.exception.CustomException;
 import yun.pioneer_back.common.exception.CustomExceptionCode;
+import yun.pioneer_back.common.repository.OwnWeaponRepository;
 import yun.pioneer_back.common.repository.UserRepository;
-import yun.pioneer_back.common.entity.UserRole;
+import yun.pioneer_back.common.repository.WeaponRepository;
 import yun.pioneer_back.common.security.jwt.TokenService;
 import yun.pioneer_back.common.security.jwt.TokenType;
 import yun.pioneer_back.common.util.EmailUtil;
@@ -31,6 +31,8 @@ import java.util.regex.Pattern;
 public class UserService
 {
     private final UserRepository userRepository;
+    private final WeaponRepository weaponRepository;
+    private final OwnWeaponRepository ownWeaponRepository;
 
     private final EmailUtil emailUtil;
     private final RedisUtil redisUtil;
@@ -183,8 +185,12 @@ public class UserService
             throw new CustomException(CustomExceptionCode.ALREADY_USED_NICKNAME, reqDto.getNickname());
         }
 
+        // 기본 무기 조회
+        Weapon basicWeapon = weaponRepository.findBasicWeapon();
+
         // 사용자 정보 생성
         User user = User.builder()
+                .mainWeapon(basicWeapon)
                 .email(reqDto.getEmail())
                 .password(bCryptPasswordEncoder.encode(reqDto.getPassword()))
                 .nickname(reqDto.getNickname())
@@ -194,6 +200,15 @@ public class UserService
 
         // 사용자 정보 저장
         userRepository.save(user);
+
+        // 기본 무기 소유 정보 생성
+        OwnWeapon ownWeapon = OwnWeapon.builder()
+                .owner(user)
+                .weapon(basicWeapon)
+                .build();
+
+        // 기본 무기 소유 정보 저장
+        ownWeaponRepository.save(ownWeapon);
     }
 
     // 비밀번호 초기화


### PR DESCRIPTION
### 연관된 이슈

#28 

<br/>

### 작업 내용

무기 소유를 의미하는 **OwnWeapon** 엔티티를 구현하였습니다.


또한, 회원가입 서비스에 다음 로직을 추가하였습니다.
- 주 무기로 기본 무기 세팅
- 기본 무기를 소유하고 있다는 정보 저장

<br/>
